### PR TITLE
feat(types): update meteora pool config schema

### DIFF
--- a/hawk-api/package.json
+++ b/hawk-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawksightco/hawk-sdk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Hawksight v2 SDK",
   "main": "dist/src/index.js",
   "repository": "https://github.com/ghabxph/hawk-api-client.git",

--- a/hawk-api/src/types.ts
+++ b/hawk-api/src/types.ts
@@ -113,12 +113,12 @@ export type OrcaPoolConfig = OrcaPoolInfo;
 export type MeteoraPoolConfig = {
   address: string,
   name: string,
-  mint_x: string,
-  mint_y: string,
-  reserve_x: string,
-  reserve_y: string,
-  reward_mint_x: string,
-  reward_mint_y: string,
+  mint_a: string,
+  mint_b: string,
+  reserve_a: string,
+  reserve_b: string,
+  reward_mint_a: string,
+  reward_mint_b: string,
   bin_step: number,
 };
 


### PR DESCRIPTION
`_x` and `_y` properties have now been renamed to `_a` and `_b` respectively